### PR TITLE
Usage example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ npm install --save ts-option
 ### Usage
 #### TypeScript
 ```
-import {Option, option, some, none} from "ts-deferred";
+import {Option, option, some, none} from "ts-option";
 
 let a: Option<number> = option(1);    // Some(1)
 let c: Option<number> = some(2);      // Some(2)
@@ -21,7 +21,7 @@ let d: Option<number> = none;         // None
 
 #### JavaScript (ES2015/ES6)
 ```
-import {Option, option, some, none} from "ts-deferred";
+import {Option, option, some, none} from "ts-option";
 
 let a = option(1);    // Some(1)
 let c = some(2);      // Some(2)


### PR DESCRIPTION
I was going to publish my version of scala-style option to npm, but when I was checking 'ts-option' this name was already linked to your lib :)

This PR fixes wrong import in the usage examples