### PR TITLE
basic version of for-comprehensions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -92,7 +92,13 @@ export abstract class Option<A> {
    */
   toArray: Array<A>;
 
+  /**
+   * Performs a for-comprehension like flatMap and map operation using the given functions
+   */
+  abstract forComprehension(...fns: ((x: any) => Option<any>)[]): Option<any>;
+
 }
+
 
 export interface Matcher<A, B> {
   some: (_: A) => B;
@@ -156,6 +162,15 @@ export class Some<A> extends Option<A> {
   get toArray(): Array<A> {
     return [this._value];
   }
+  forComprehension(...fns: ((x: any) => Option<any>)[]): Option<any> {
+    let result: Option<any> = this;
+
+    for (let i = 0; i < fns.length - 1; i++) {
+      result = result.flatMap(fns[i]);
+    }
+
+    return result.map(fns[fns.length -1]);
+  }
 }
 
 export class None extends Option<any> {
@@ -209,6 +224,9 @@ export class None extends Option<any> {
   }
   get toArray(): Array<any> {
     return [];
+  }
+  forComprehension<B>(...fns: ((x: any) => Option<B>)[]): Option<B> {
+    return this;
   }
 }
 

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -167,6 +167,25 @@ describe("Some", () => {
     });
   });
 
+  describe("#forComprehension", () => {
+    it("should flat map every method except the last, which is mapped", () => {
+      const nestedOptions = some({
+        anOption: some({
+          anotherOption: some({
+            finalValue: true
+          })
+        })
+      });
+
+      const result = nestedOptions.forComprehension(
+        obj => obj.anOption,
+        anOption => anOption.anotherOption,
+        anotherOption => anotherOption.finalValue
+      );
+
+      assert(result.get === true);
+    });
+  });
 });
 
 describe("None", () => {
@@ -307,5 +326,24 @@ describe("None", () => {
       assert(xs.length === 0);
     });
   });
+
+  describe("#forComprehension", () => {
+    it("should return none", () => {
+      const nestedOptions = some({
+        anOption: some({
+          anotherOption: none
+        })
+      });
+
+      const result = nestedOptions.forComprehension(
+        obj => obj.anOption,
+        anOption => anOption.anotherOption,
+        anotherOption => anotherOption.finalValue
+      );
+
+      assert(result === none);
+    });
+  });
+
 
 });


### PR DESCRIPTION
This PR adds a basic implementation of Scala's for-comprehension.

It will only apply flatMap and map. Any filtering must be done manually. 

Example usage can be seen in the tests but I would be happy to add documentation.

There is one limitation in that the type information is of the final result is lost and returned as `Option<any>`. In theory it should be `Option<B>` where `B` is the result type of the last function. Unfortunately it is not possible to get the type information of the last element of an array defined by a rest argument.