### PR TITLE
allow raw values for getOrElse

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,7 +50,7 @@ export abstract class Option<A> {
   /**
    * Returns the option's value if the option is non-empty, otherwise return the result of evaluating default.
    */
-  abstract getOrElse(defaultValue: () => A): A;
+  abstract getOrElse(defaultValue: A | (() => A)): A;
 
   /**
    * Returns true if the option's value is non-empty, false otherwise.
@@ -129,7 +129,7 @@ export class Some<A> extends Option<A> {
   get get(): A {
     return this._value;
   }
-  getOrElse(defaultValue: () => any): A {
+  getOrElse(defaultValue: A | (() => A)): A {
     return this._value;
   }
   get isDefined(): boolean {
@@ -183,8 +183,8 @@ export class None extends Option<any> {
   get get(): any {
     throw new Error('No such element.');
   }
-  getOrElse(defaultValue: () => any): any {
-    return defaultValue();
+  getOrElse(defaultValue: any | (() => any)): any {
+    return typeof defaultValue === "function" ? defaultValue() : defaultValue;
   }
   get isDefined(): boolean {
     return false;

--- a/test/spec.ts
+++ b/test/spec.ts
@@ -106,7 +106,10 @@ describe("Some", () => {
   });
 
   describe("#getOrElse", () => {
-    it("should returns the option's value.", () => assert(some(123).getOrElse(() => 456) === 123));
+    it("should returns the option's value.", () => {
+      assert(some(123).getOrElse(() => 456) === 123);
+      assert(some(123).getOrElse(456) === 123);
+    });
   });
 
   describe("#isDefined", () => {
@@ -249,7 +252,10 @@ describe("None", () => {
   });
 
   describe("#getOrElse", () => {
-    it("should returns `defaultValue`.", () => assert(none.getOrElse(() => 123) === 123));
+    it("should returns `defaultValue`.", () => {
+      assert(none.getOrElse(() => 123) === 123);
+      assert(none.getOrElse(123) === 123);
+    });
   });
 
   describe("#isDefined", () => {


### PR DESCRIPTION
This change allows passing of a raw value to the getOrElse method.

There is a performance overhead to consider but I believe the convenience is worth it.