### PR TITLE
Fix forAll behaviour for None

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -190,7 +190,7 @@ export class None extends Option<any> {
     return () => ifEmpty();
   }
   forAll(p: (_: any) => boolean): boolean {
-    return false;
+    return true;
   }
   forEach(f: (_: any) => any): void {
     // do nothing.


### PR DESCRIPTION
As I understand the lib, it replicates the scala Option semantics, which are backed by a bit of set theory, which ultimately implies that none.forAll() is always true ! There's a good explanation here : http://blog.originate.com/blog/2014/06/15/idiomatic-scala-your-options-do-not-match/

Otherwise, forAll() would be strictly equivalent to exists, with no point in having both :)

Cheers !